### PR TITLE
Add pangeo-escience object store

### DIFF
--- a/EGI-CLI-Swift-S3.md
+++ b/EGI-CLI-Swift-S3.md
@@ -47,8 +47,17 @@ export OS_AUTH_TYPE=v3oidcaccesstoken
 export OS_PROTOCOL=openid
 export OS_IDENTITY_PROVIDER=egi.eu
 export OS_ACCESS_TOKEN=$OIDC_ACCESS_TOKEN
-export OS_PROJECT_ID=57102d3e06b7476088fe4924370ae170
 export OS_STORAGE_URL=https://object-store.cloud.muni.cz/swift/v1
+```
+
+Depending on the workshop you are attending, configure the project ID accordingly:
+```
+# CLIVAR workshop:
+# https://www.clivar.org/events/arctic-processes-cmip6-bootcamp
+export OS_PROJECT_ID=57102d3e06b7476088fe4924370ae170
+# eScience workshop:
+# https://www.aces.su.se/research/projects/escience-tools-in-climate-science-linking-observations-with-modelling/
+export OS_PROJECT_ID=5e5a45e153d3424997fda0c4fd21a21f
 ```
 
 Then the following command should work:

--- a/WEB-Object_storage-Creation.md
+++ b/WEB-Object_storage-Creation.md
@@ -17,10 +17,12 @@ Click '+Container', and in the pop up window labelled _Create Container_, define
 
 Please see below a table with the permissions to access object storage.
 
-Virtual Organisation | Create/destroy VMs | Public bucket for "vo.pangeo.eu" | Private bucket for "vo.pangeo.eu" | Public bucket for "vo.pangeo.eu-swift" | Private bucket for "vo.pangeo.eu-swift"
--- | -- | -- | -- | -- | --
-member of vo.pangeo.eu in aai.egi.eu/pangeo.admins | yes | read/write access | read/write access | read-write access | read/write access
-member of vo.pangeo.eu in aai.egi.eu | no | read-only | no access | read/write access | read/write access
-member of vo.pangeo.eu in aai-dev.egi.eu | no | read-only | no access | read-only | no access
-None | no | read-only | no access | read-only | no access
+  | Create/destroy VMs | Object Storage at OpenStack: project "vo.pangeo.eu" | Object Storage at OpenStack: project "vo.pangeo.eu" | Object Storage at OpenStack: project "vo.pangeo.eu-swift" | Object Storage at OpenStack: project "vo.pangeo.eu-swift" | Object Storage at OpenStack: project "vo.pangeo.eu-escience" | Object Storage at OpenStack: project "vo.pangeo.eu-escience"
+-- | -- | -- | -- | -- | -- | -- | --
+Virtual Organisation |   | Public bucket | Private bucket | Public bucket | Private bucket | Public bucket | Private bucket
+member of vo.pangeo.eu in aai.egi.eu/pangeo.admins | yes | read/write access | read/write access | read-write access | read/write access | read-only | no access
+member of vo.pangeo.eu in aai.egi.eu | no | read-only | no access | read/write access | read/write access | read-only | no access
+member of vo.pangeo.eu in aai.egi.eu/escience | no | read-only | no access | read-only | no access | read/write access | read/write access
+member of vo.pangeo.eu in aai-dev.egi.eu | no | read-only | no access | read-only | no access | read-only | no access
+None | no | read-only | no access | read-only | no access | read-only | no access
 


### PR DESCRIPTION
New OpenStack project and Check-In group available.

Please remember that attendees for the eScience workhop need to be added to the `pangeo.escience` group in Check-In:
https://docs.egi.eu/users/aai/check-in/vos/#adding-members-to-vo-groups
