### PR TITLE
Increase resources for minio

### DIFF
--- a/providers/kubernetes/minio/minio.yaml
+++ b/providers/kubernetes/minio/minio.yaml
@@ -15,13 +15,13 @@ extraEnvVars:
 
 resources:
   limits:
-    cpu: "2"
+    cpu: "4"
     ephemeral-storage: "10Gi"
-    memory: "1Gi"
+    memory: "8Gi"
   requests:
-    cpu: "375m"
+    cpu: "1"
     ephemeral-storage: "2Gi"
-    memory: "384Mi"
+    memory: "2Gi"
 
 ingress:
   enabled: true


### PR DESCRIPTION

Observed `CrashLoopBackOff` in the `minio` pod:

```
Events:
  Type     Reason     Age                     From     Message
  ----     ------     ----                    ----     -------
  Warning  Unhealthy  8m42s (x158 over 5d1h)  kubelet  Liveness probe failed: Get "http://10.42.231.31:9000/minio/health/live": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
  Normal   Killing    8m22s (x37 over 3h14m)  kubelet  Container minio failed liveness probe, will be restarted
  Warning  BackOff    4m45s (x394 over 168m)  kubelet  Back-off restarting failed container minio in pod minio-b96d46b8-89jcm_c-scale-pangeo-dask(19762344-9da8-43ea-aad7-9cc48cd08ea4)
```

Increasing resources in an attempt to fix the issue.