### PR TITLE
Update ingress config

### DIFF
--- a/providers/kubernetes/daskhub.yaml
+++ b/providers/kubernetes/daskhub.yaml
@@ -162,10 +162,10 @@ jupyterhub:
 
   ingress:
     annotations:
-      kubernetes.io/ingress.class: nginx
       cert-manager.io/cluster-issuer: "letsencrypt-prod"
       nginx.ingress.kubernetes.io/proxy-body-size: "1g"
     enabled: true
+    ingressClassName: nginx
     hosts:
       - pangeo-eosc.vm.fedcloud.eu # replace this with your DNS name
     tls:


### PR DESCRIPTION

See:
* https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/
* https://doc.traefik.io/traefik/reference/routing-configuration/kubernetes/ingress-nginx/
* https://doc.traefik.io/traefik/reference/install-configuration/providers/kubernetes/kubernetes-ingress-nginx/

Confirmed with sysadmin that for this deployment we just need this configuration change
